### PR TITLE
Feat/be daily

### DIFF
--- a/backend/src/main/java/com/cs101/BackendApplication.java
+++ b/backend/src/main/java/com/cs101/BackendApplication.java
@@ -2,8 +2,10 @@ package com.cs101;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/cs101/api/controller/KnowledgeController.java
+++ b/backend/src/main/java/com/cs101/api/controller/KnowledgeController.java
@@ -1,0 +1,27 @@
+package com.cs101.api.controller;
+
+import com.cs101.api.service.KnowledgeService;
+import com.cs101.dto.request.CreateKnowledgeReq;
+import com.cs101.dto.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/knowledge")
+public class KnowledgeController {
+    private final KnowledgeService knowledgeService;
+    @PostMapping
+    public ResponseEntity<ApiResponse> createKnowledge(@RequestBody CreateKnowledgeReq createKnowledgeReq) throws IOException {
+        knowledgeService.createKnowledge(createKnowledgeReq);
+        return ResponseEntity
+                .ok()
+                .body(new ApiResponse(201, "지식 등록 성공", null));
+    }
+}

--- a/backend/src/main/java/com/cs101/api/repository/DailyRepository.java
+++ b/backend/src/main/java/com/cs101/api/repository/DailyRepository.java
@@ -1,0 +1,7 @@
+package com.cs101.api.repository;
+
+import com.cs101.entity.Daily;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyRepository extends JpaRepository<Daily, Long> {
+}

--- a/backend/src/main/java/com/cs101/api/repository/KnowledgeRepository.java
+++ b/backend/src/main/java/com/cs101/api/repository/KnowledgeRepository.java
@@ -1,0 +1,7 @@
+package com.cs101.api.repository;
+
+import com.cs101.entity.Knowledge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KnowledgeRepository extends JpaRepository<Knowledge, Long> {
+}

--- a/backend/src/main/java/com/cs101/api/repository/UserRepository.java
+++ b/backend/src/main/java/com/cs101/api/repository/UserRepository.java
@@ -2,9 +2,13 @@ package com.cs101.api.repository;
 
 import com.cs101.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+//    @Query("SELECT COUNT(*) FROM User u")
+//    Long getUserSize();
 }

--- a/backend/src/main/java/com/cs101/api/service/KnowledgeService.java
+++ b/backend/src/main/java/com/cs101/api/service/KnowledgeService.java
@@ -1,0 +1,24 @@
+package com.cs101.api.service;
+
+import com.cs101.api.repository.KnowledgeRepository;
+import com.cs101.dto.request.CreateKnowledgeReq;
+import com.cs101.entity.Knowledge;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class KnowledgeService {
+    private final KnowledgeRepository knowledgeRepository;
+
+    public void createKnowledge(CreateKnowledgeReq createKnowledgeReq) throws IOException {
+        Knowledge knowledge = Knowledge.builder()
+                .content(createKnowledgeReq.getContent())
+                .build();
+        knowledgeRepository.save(knowledge);
+    }
+}

--- a/backend/src/main/java/com/cs101/dto/request/CreateKnowledgeReq.java
+++ b/backend/src/main/java/com/cs101/dto/request/CreateKnowledgeReq.java
@@ -1,0 +1,12 @@
+package com.cs101.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateKnowledgeReq {
+    private String content;
+}

--- a/backend/src/main/java/com/cs101/entity/Daily.java
+++ b/backend/src/main/java/com/cs101/entity/Daily.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Builder
 public class Daily {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/cs101/entity/Knowledge.java
+++ b/backend/src/main/java/com/cs101/entity/Knowledge.java
@@ -10,6 +10,7 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @ToString(of = {"id", "content"})
+@Builder
 public class Knowledge {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/cs101/util/SchedulerUtil.java
+++ b/backend/src/main/java/com/cs101/util/SchedulerUtil.java
@@ -1,0 +1,56 @@
+package com.cs101.util;
+
+import com.cs101.api.repository.DailyRepository;
+import com.cs101.api.repository.UserRepository;
+import com.cs101.entity.Daily;
+import com.cs101.entity.User;
+import com.cs101.entity.UserStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Component
+@RequiredArgsConstructor
+public class SchedulerUtil {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+
+//    @Scheduled(cron="0 16 19 * * ?")
+//    public void test() throws IOException {
+//        for(int i=1;i<=5;i++){
+//            User user = User.builder()
+//                    .email("aa@aa.com")
+//                    .password(passwordEncoder.encode("1111"))
+//                    .name("sangwoo")
+//                    .registeredDate(LocalDateTime.now())
+//                    .userStatus(UserStatus.ACTIVATED)
+//                    .build();
+//            userRepository.save(user);
+//        }
+//        Long userSize = userRepository.getUserSize();
+//        Random random = new Random();
+//        Long randomId = (long) (random.nextDouble()*userSize)+1;
+//    }
+
+    private final DailyRepository dailyRepository;
+
+//    @Scheduled(cron="0 0 0 * * ?")
+//    public void createDaily() throws IOException {
+//        System.out.println("Daily information updated");
+//        Daily daily = Daily.builder()
+//                .date(LocalDate.now())
+//                .dailyProblemId1(1L)
+//                .dailyProblemId2(2L)
+//                .dailyProblemId3(3L)
+//                .dailyKnowledge(null)
+//                .build();
+//        dailyRepository.save(daily);
+//    }
+}


### PR DESCRIPTION
## 🚀 목적

- 오늘의 문제, 오늘의 지식 저장을 위한 스케줄러의 사용
  

## 🖥️ 주요 변경사항

- 매일 0시마다 db에 새로운 정보가 저장될 수 있도록 코드 작성
  - BackendApplication에 springbatch의 scheduler 사용 가능하도록 작성
  - SchedulerUtil에 코드 작성
- knowledge를 생성할 수 있는 api 작성

  
## ❗이슈

- 아직 문제가 존재하지 않기 때문에 0시마다 유저 한명을 생성하도록 구현하였으며, 실제 작동되지 않도록 주석처리하였음
  - 나중에 랜덤 문제 3개의 id와 랜덤 지식 한개를 daily에 저장하도록 코드 변경 예정
