### PR TITLE
feat/be-auth

### DIFF
--- a/backend/src/main/java/com/cs101/api/controller/AuthController.java
+++ b/backend/src/main/java/com/cs101/api/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.cs101.api.controller;
 
 import com.cs101.api.service.AuthService;
+import com.cs101.api.service.UserService;
 import com.cs101.dto.request.LoginReq;
 import com.cs101.dto.request.RegisterUserReq;
 import com.cs101.dto.request.RejoinUserReq;
@@ -29,9 +30,15 @@ public class AuthController {
     private final AuthService authService;
     private final JwtUtil jwtUtil;
     private final CookieUtil cookieUtil;
+    private final UserService userService;
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse> registerUser(@RequestBody RegisterUserReq registerUserReq) throws IOException {
+        if (userService.existsByEmail(registerUserReq.getEmail())) {
+            return ResponseEntity
+                    .ok()
+                    .body(new ApiResponse(403, "이미 존재하는 이메일입니다.", null));
+        }
         authService.registerUser(registerUserReq);
         return ResponseEntity
                 .ok()

--- a/backend/src/main/java/com/cs101/api/controller/PendingProblemController.java
+++ b/backend/src/main/java/com/cs101/api/controller/PendingProblemController.java
@@ -48,7 +48,6 @@ public class PendingProblemController {
     @PutMapping("/authorization/{pendingProblemId}")
     public ResponseEntity<ApiResponse> refuseProblem(@PathVariable Long pendingProblemId) throws IOException {
         if (userService.checkAdmin(jwtUtil.getUserId())) {
-
             pendingProblemService.refuseProblem(pendingProblemId);
             return ResponseEntity
                     .ok()

--- a/backend/src/main/java/com/cs101/api/controller/PendingProblemController.java
+++ b/backend/src/main/java/com/cs101/api/controller/PendingProblemController.java
@@ -38,9 +38,9 @@ public class PendingProblemController {
                 .body(new ApiResponse(200, "등록 대기 문제 승인 성공", null));
     }
 
-    @PutMapping("/authorization/{problemId}")
-    public ResponseEntity<ApiResponse> refuseProblem(@PathVariable Long problemId) throws IOException {
-        pendingProblemService.refuseProblem(problemId);
+    @PutMapping("/authorization/{pendingProblemId}")
+    public ResponseEntity<ApiResponse> refuseProblem(@PathVariable Long pendingProblemId) throws IOException {
+        pendingProblemService.refuseProblem(pendingProblemId);
         return ResponseEntity
                 .ok()
                 .body(new ApiResponse(200, "등록 대기 문제 거절 성공", null));

--- a/backend/src/main/java/com/cs101/api/controller/PendingProblemController.java
+++ b/backend/src/main/java/com/cs101/api/controller/PendingProblemController.java
@@ -5,6 +5,7 @@ import com.cs101.dto.request.CreatePendingProblemReq;
 import com.cs101.dto.request.AcceptProblemReq;
 import com.cs101.dto.request.PendingProblemFilter;
 import com.cs101.dto.response.ApiResponse;
+import com.cs101.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -17,10 +18,12 @@ import java.io.IOException;
 @RequestMapping("/problem/pending")
 public class PendingProblemController {
     private final PendingProblemService pendingProblemService;
+    private final JwtUtil jwtUtil;
+
 
     @PostMapping
     public ResponseEntity<ApiResponse> createPendingProblem(@RequestBody CreatePendingProblemReq createPendingProblemReq) throws IOException {
-        Long userId = 1L;
+        Long userId = jwtUtil.getUserId();
         pendingProblemService.createPendingProblem(createPendingProblemReq, userId);
         return ResponseEntity
                 .ok()

--- a/backend/src/main/java/com/cs101/api/controller/PendingProblemController.java
+++ b/backend/src/main/java/com/cs101/api/controller/PendingProblemController.java
@@ -29,7 +29,7 @@ public class PendingProblemController {
         pendingProblemService.createPendingProblem(createPendingProblemReq, userId);
         return ResponseEntity
                 .ok()
-                .body(new ApiResponse(200, "문제 등록 성공", null));
+                .body(new ApiResponse(201, "문제 등록 성공", null));
     }
 
     @PostMapping("/authorization")
@@ -38,7 +38,7 @@ public class PendingProblemController {
             pendingProblemService.acceptProblem(acceptProblemReq);
             return ResponseEntity
                     .ok()
-                    .body(new ApiResponse(200, "등록 대기 문제 승인 성공", null));
+                    .body(new ApiResponse(201, "등록 대기 문제 승인 성공", null));
         }
         return ResponseEntity
                 .ok()
@@ -52,7 +52,7 @@ public class PendingProblemController {
             pendingProblemService.refuseProblem(pendingProblemId);
             return ResponseEntity
                     .ok()
-                    .body(new ApiResponse(200, "등록 대기 문제 거절 성공", null));
+                    .body(new ApiResponse(201, "등록 대기 문제 거절 성공", null));
         }
         return ResponseEntity
                 .ok()

--- a/backend/src/main/java/com/cs101/api/controller/PendingProblemController.java
+++ b/backend/src/main/java/com/cs101/api/controller/PendingProblemController.java
@@ -1,6 +1,7 @@
 package com.cs101.api.controller;
 
 import com.cs101.api.service.PendingProblemService;
+import com.cs101.api.service.UserService;
 import com.cs101.dto.request.CreatePendingProblemReq;
 import com.cs101.dto.request.AcceptProblemReq;
 import com.cs101.dto.request.PendingProblemFilter;
@@ -19,6 +20,7 @@ import java.io.IOException;
 public class PendingProblemController {
     private final PendingProblemService pendingProblemService;
     private final JwtUtil jwtUtil;
+    private final UserService userService;
 
 
     @PostMapping
@@ -32,18 +34,29 @@ public class PendingProblemController {
 
     @PostMapping("/authorization")
     public ResponseEntity<ApiResponse> acceptProblem(@RequestBody AcceptProblemReq acceptProblemReq) throws IOException {
-        pendingProblemService.acceptProblem(acceptProblemReq);
+        if (userService.checkAdmin(jwtUtil.getUserId())) {
+            pendingProblemService.acceptProblem(acceptProblemReq);
+            return ResponseEntity
+                    .ok()
+                    .body(new ApiResponse(200, "등록 대기 문제 승인 성공", null));
+        }
         return ResponseEntity
                 .ok()
-                .body(new ApiResponse(200, "등록 대기 문제 승인 성공", null));
+                .body(new ApiResponse(406, "권한 없음", null));
     }
 
     @PutMapping("/authorization/{pendingProblemId}")
     public ResponseEntity<ApiResponse> refuseProblem(@PathVariable Long pendingProblemId) throws IOException {
-        pendingProblemService.refuseProblem(pendingProblemId);
+        if (userService.checkAdmin(jwtUtil.getUserId())) {
+
+            pendingProblemService.refuseProblem(pendingProblemId);
+            return ResponseEntity
+                    .ok()
+                    .body(new ApiResponse(200, "등록 대기 문제 거절 성공", null));
+        }
         return ResponseEntity
                 .ok()
-                .body(new ApiResponse(200, "등록 대기 문제 거절 성공", null));
+                .body(new ApiResponse(406, "권한 없음", null));
     }
 
     @GetMapping

--- a/backend/src/main/java/com/cs101/api/controller/ProblemController.java
+++ b/backend/src/main/java/com/cs101/api/controller/ProblemController.java
@@ -4,6 +4,7 @@ import com.cs101.api.service.ProblemService;
 import com.cs101.dto.request.ProblemFilter;
 import com.cs101.dto.request.SubmitAnswerReq;
 import com.cs101.dto.response.ApiResponse;
+import com.cs101.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -14,10 +15,12 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/problem")
 public class ProblemController {
     private final ProblemService problemService;
+    private final JwtUtil jwtUtil;
+
 
     @PostMapping
     public ResponseEntity<ApiResponse> submitAnswer(@RequestBody SubmitAnswerReq submitAnswerReq) {
-        Long userId = 1L;
+        Long userId = jwtUtil.getUserId();
         return ResponseEntity
                 .ok()
                 .body(new ApiResponse(200, "답안 제출 성공", problemService.checkAnswer(userId, submitAnswerReq.getProblemId(), submitAnswerReq.getAnswer())));
@@ -32,6 +35,8 @@ public class ProblemController {
 
     @GetMapping
     public ResponseEntity<ApiResponse> getProblemList(@RequestParam(value = "categories", required = false) String categories, @RequestParam(value = "types", required = false) String types, @RequestParam(value = "statuses", required = false) String statuses, @RequestParam(value = "favorites", required = false) String favorites, Pageable pageable) {
+        Long userId = jwtUtil.getUserId();
+
         ProblemFilter filter = new ProblemFilter();
         if (categories != null) filter.setCategories(categories);
         if (types != null) filter.setTypes(types);
@@ -40,12 +45,12 @@ public class ProblemController {
 
         return ResponseEntity
                 .ok()
-                .body(new ApiResponse(200, "문제 목록 조회 성공", problemService.getProblemList(filter, pageable)));
+                .body(new ApiResponse(200, "문제 목록 조회 성공", problemService.getProblemList(userId, filter, pageable)));
     }
 
     @GetMapping("/{problemId}")
     public ResponseEntity<ApiResponse> getProblemDetail(@PathVariable Long problemId){
-        Long userId = 1L;
+        Long userId = jwtUtil.getUserId();
         return ResponseEntity
                 .ok()
                 .body(new ApiResponse(200, "문제 상세 조회 성공", problemService.getProblemDetail(userId, problemId)));
@@ -53,7 +58,7 @@ public class ProblemController {
 
     @PostMapping("/favorites/{problemId}")
     public ResponseEntity<ApiResponse> addFavorites(@PathVariable Long problemId){
-        Long userId = 1L;
+        Long userId = jwtUtil.getUserId();
         problemService.addFavorites(userId, problemId);
         return ResponseEntity
                 .ok()
@@ -62,7 +67,7 @@ public class ProblemController {
 
     @DeleteMapping("/favorites/{problemId}")
     public ResponseEntity<ApiResponse> deleteFavorites(@PathVariable Long problemId){
-        Long userId = 1L;
+        Long userId = jwtUtil.getUserId();
         problemService.deleteFavorites(userId, problemId);
         return ResponseEntity
                 .ok()

--- a/backend/src/main/java/com/cs101/api/controller/ProblemController.java
+++ b/backend/src/main/java/com/cs101/api/controller/ProblemController.java
@@ -23,7 +23,7 @@ public class ProblemController {
         Long userId = jwtUtil.getUserId();
         return ResponseEntity
                 .ok()
-                .body(new ApiResponse(200, "답안 제출 성공", problemService.checkAnswer(userId, submitAnswerReq.getProblemId(), submitAnswerReq.getAnswer())));
+                .body(new ApiResponse(201, "답안 제출 성공", problemService.checkAnswer(userId, submitAnswerReq.getProblemId(), submitAnswerReq.getAnswer())));
     }
 
     @GetMapping("/listInfo")
@@ -62,7 +62,7 @@ public class ProblemController {
         problemService.addFavorites(userId, problemId);
         return ResponseEntity
                 .ok()
-                .body(new ApiResponse(200, "즐겨찾기 추가 성공", null));
+                .body(new ApiResponse(201, "즐겨찾기 추가 성공", null));
     }
 
     @DeleteMapping("/favorites/{problemId}")
@@ -71,6 +71,6 @@ public class ProblemController {
         problemService.deleteFavorites(userId, problemId);
         return ResponseEntity
                 .ok()
-                .body(new ApiResponse(200, "즐겨찾기 삭제 성공", null));
+                .body(new ApiResponse(201, "즐겨찾기 삭제 성공", null));
     }
 }

--- a/backend/src/main/java/com/cs101/api/controller/ReportController.java
+++ b/backend/src/main/java/com/cs101/api/controller/ReportController.java
@@ -6,6 +6,7 @@ import com.cs101.dto.request.ProblemFilter;
 import com.cs101.dto.request.ReportFilter;
 import com.cs101.dto.request.UpdateReportReq;
 import com.cs101.dto.response.ApiResponse;
+import com.cs101.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,10 +18,12 @@ import java.io.IOException;
 @RequestMapping("/report")
 public class ReportController {
     private final ReportService reportService;
+    private final JwtUtil jwtUtil;
+
 
     @PostMapping
     public ResponseEntity<ApiResponse> createReport(@RequestBody CreateReportReq createReportReq) throws IOException {
-        Long userId = 1L;
+        Long userId = jwtUtil.getUserId();
         reportService.createReport(createReportReq, userId);
         return ResponseEntity
                 .ok()

--- a/backend/src/main/java/com/cs101/api/controller/UserController.java
+++ b/backend/src/main/java/com/cs101/api/controller/UserController.java
@@ -27,8 +27,7 @@ public class UserController {
 
     @PutMapping()
     public ResponseEntity<ApiResponse> updateUser(@RequestBody UpdateUserReq updateUserReq) throws IOException {
-//        Long userId = jwtUtil.getUserId();
-        Long userId = 1L;
+        Long userId = jwtUtil.getUserId();
         userService.updateUser(updateUserReq, userId);
         return ResponseEntity
                 .ok()

--- a/backend/src/main/java/com/cs101/api/repository/UserRepository.java
+++ b/backend/src/main/java/com/cs101/api/repository/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/backend/src/main/java/com/cs101/api/service/PendingProblemService.java
+++ b/backend/src/main/java/com/cs101/api/service/PendingProblemService.java
@@ -65,7 +65,7 @@ public class PendingProblemService {
 
     public void acceptProblem(AcceptProblemReq acceptProblemReq) throws IOException {
         User user = userRepository.findById(acceptProblemReq.getAuthorId()).orElseThrow(() -> new NoUserByIdException("" + acceptProblemReq.getAuthorId()));
-        PendingProblem pendingProblem = pendingProblemRepository.findById(acceptProblemReq.getProblemId()).orElseThrow(() -> new NoProblemByIdException("" + acceptProblemReq.getProblemId()));
+        PendingProblem pendingProblem = pendingProblemRepository.findById(acceptProblemReq.getPendingProblemId()).orElseThrow(() -> new NoProblemByIdException("" + acceptProblemReq.getPendingProblemId()));
         Category category = categoryRepository.findByName(acceptProblemReq.getCategory()).orElseThrow(() -> new NoCategoryByNameException(acceptProblemReq.getCategory()));
         Type type = typeRepository.findByName(acceptProblemReq.getType()).orElseThrow(() -> new NoTypeByNameException(acceptProblemReq.getType()));
 
@@ -89,8 +89,8 @@ public class PendingProblemService {
         pendingProblemRepository.updatePendingStatus(pendingProblem, PendingStatus.ACCEPTED);
     }
 
-    public void refuseProblem(Long problemId) {
-        PendingProblem pendingProblem = pendingProblemRepository.findById(problemId).orElseThrow(() -> new NoProblemByIdException("" + problemId));
+    public void refuseProblem(Long pendingProblemId) {
+        PendingProblem pendingProblem = pendingProblemRepository.findById(pendingProblemId).orElseThrow(() -> new NoProblemByIdException("" + pendingProblemId));
 
         pendingProblemRepository.updatePendingStatus(pendingProblem, PendingStatus.REJECTED);
     }

--- a/backend/src/main/java/com/cs101/api/service/ProblemService.java
+++ b/backend/src/main/java/com/cs101/api/service/ProblemService.java
@@ -37,8 +37,8 @@ public class ProblemService {
         return problemListInfoRes;
     }
 
-    public Page<ProblemListItem> getProblemList(ProblemFilter filter, Pageable pageable) {
-        return problemRepository.findByFilter(1L, filter, pageable);
+    public Page<ProblemListItem> getProblemList(Long userId, ProblemFilter filter, Pageable pageable) {
+        return problemRepository.findByFilter(userId, filter, pageable);
     }
 
     public List<Problem> getProblems() {
@@ -49,7 +49,7 @@ public class ProblemService {
         User user = userRepository.findById(userId).orElseThrow(() -> new NoUserByIdException(String.valueOf(userId)));
         Problem problem = problemRepository.findById(problemId).orElseThrow(() -> new NoProblemByIdException(String.valueOf(problemId)));
         Boolean isFavorite = favoritesRepository.findById(user, problem).isPresent();
-        UserProblemStatus status = userProblemRepository.getProblemStatus(1L, 1L).orElse(UserProblemStatus.UNSOLVED);
+        UserProblemStatus status = userProblemRepository.getProblemStatus(userId, problemId).orElse(UserProblemStatus.UNSOLVED);
 
         ProblemDetail problemDetail = ProblemDetail.builder()
                 .question(problem.getQuestion())

--- a/backend/src/main/java/com/cs101/api/service/UserService.java
+++ b/backend/src/main/java/com/cs101/api/service/UserService.java
@@ -67,4 +67,6 @@ public class UserService {
         User user = userRepository.findById(userId).orElse(null);
         return user.isAdmin();
     }
+
+    public boolean existsByEmail(String email) {return userRepository.existsByEmail(email);}
 }

--- a/backend/src/main/java/com/cs101/api/service/UserService.java
+++ b/backend/src/main/java/com/cs101/api/service/UserService.java
@@ -62,4 +62,9 @@ public class UserService {
             }
         }
     }
+
+    public boolean checkAdmin(Long userId) {
+        User user = userRepository.findById(userId).orElse(null);
+        return user.isAdmin();
+    }
 }

--- a/backend/src/main/java/com/cs101/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/cs101/config/WebMvcConfig.java
@@ -1,0 +1,77 @@
+package com.cs101.config;
+
+import com.cs101.interceptor.JwtInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CommonsRequestLoggingFilter;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import javax.servlet.Filter;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+    private static final String[] EXCLUDE_PATHS = {
+            "/**"
+    };
+
+    @Autowired
+    private JwtInterceptor jwtInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(jwtInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns(EXCLUDE_PATHS);
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        // configuration.addAllowedOrigin("*");
+        configuration.addAllowedOriginPattern("*");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+//        configuration.addExposedHeader(JwtTokenUtil.HEADER_STRING);
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/resources/**")
+                .addResourceLocations("/WEB-INF/resources/");
+
+        registry.addResourceHandler("swagger-ui.html")
+                .addResourceLocations("classpath:/META-INF/resources/");
+
+        registry.addResourceHandler("/webjars/**")
+                .addResourceLocations("classpath:/META-INF/resources/webjars/");
+    }
+
+    public Filter requestLoggingFilter() {
+        CommonsRequestLoggingFilter loggingFilter = new CommonsRequestLoggingFilter();
+        loggingFilter.setIncludeClientInfo(true);
+        loggingFilter.setIncludeQueryString(true);
+        loggingFilter.setIncludePayload(true);
+        loggingFilter.setIncludeHeaders(true);
+        loggingFilter.setMaxPayloadLength(64000);
+        return loggingFilter;
+    }
+
+    @Bean
+    public FilterRegistrationBean loggingFilterRegistration() {
+        FilterRegistrationBean registration = new FilterRegistrationBean(requestLoggingFilter());
+        registration.addUrlPatterns("/*");
+        return registration;
+    }
+}

--- a/backend/src/main/java/com/cs101/dto/request/AcceptProblemReq.java
+++ b/backend/src/main/java/com/cs101/dto/request/AcceptProblemReq.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AcceptProblemReq {
-    private Long problemId;
+    private Long pendingProblemId;
     private String title;
     private String category;
     private String type;

--- a/backend/src/main/java/com/cs101/interceptor/JwtInterceptor.java
+++ b/backend/src/main/java/com/cs101/interceptor/JwtInterceptor.java
@@ -1,0 +1,64 @@
+package com.cs101.interceptor;
+
+import com.cs101.util.JwtUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class JwtInterceptor implements HandlerInterceptor {
+    private static final String HEADER_AUTH = "Authorization";
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // axios의 Preflight OPTION 요청 거름
+        if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+            return true;
+        }
+
+        // cookie에서 토큰들을 가져옴(없으면 null)
+        String bearer = request.getHeader(HEADER_AUTH);
+        String accessToken = null;
+        String refreshToken = null;
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies == null) {
+            return true;
+        }
+
+        if (bearer != null && !"".equals(bearer)) {
+            final String token = request.getHeader(HEADER_AUTH).split(" ")[1];
+            try {
+                if (token != null && !"".equals(bearer) && jwtUtil.isUsable(token)) {
+                    return true;
+                }
+            } catch (ExpiredJwtException e) {
+                response.sendError(445, "다시 로그인해주세요");
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+
+        Cookie accessCookie = new Cookie("accessToken", null);
+        accessCookie.setMaxAge(0);
+        accessCookie.setPath("/");
+        response.addCookie(accessCookie);
+
+        Cookie refreshCookie = new Cookie("refreshToken", null);
+        refreshCookie.setMaxAge(0);
+        refreshCookie.setPath("/");
+        response.addCookie(refreshCookie);
+
+        response.sendError(445, "다시 로그인해주세요. (2)");
+        return false;
+    }
+}


### PR DESCRIPTION
## 🚀 목적

- 현재 사용자가 누구인지 확인이 필요한 모든 곳 손보기
  

## 🖥️ 주요 변경사항

- 회원정보 수정/신고등록/문제등록/각종 상황별 문제 정보 가져오기에서 현재 유저가 누군지 확인하는 코드 추가
- 대기중인 문제를 승인/거절하는 과정에서 넘겨줘야하는 id를 헷갈리지 않게 problemId로 되어있던걸 pendingProblemId로 바꿈
- 상태 코드 변경
- 회원가입시 이메일 중복 확인 코드 추가
- 문제 승인/거절 시 관리자인지 확인하는 코드 추가
- webMvcConfig/jwtInterceptor 임시로 추가(프론트 연동 이후 수정 예정)
 

